### PR TITLE
Save skeleton images

### DIFF
--- a/main.py
+++ b/main.py
@@ -142,6 +142,8 @@ def init(fpath, io):
         os.makedirs(os.path.join('Crown','Plots'))
     if not os.path.exists(os.path.join('Crown','Result')):
         os.makedirs(os.path.join('Crown','Result'))
+    if not os.path.exists(os.path.join('Crown','Skeleton')):
+        os.mkdirs(os.path.join('Crown','Skeleton'))
     
     os.chdir(oldpath)
     readTraits(options[12][1])
@@ -290,6 +292,7 @@ def threadCrown(filepath):
                 currT=time.time()
                 skel=Skeleton.Skeleton(imgL)
                 testSkel,testDia=skel.skel(imgL)
+                scipy.misc.imsave(io.getHomePath() + '/Skeleton/' + io.getFileName() + '_skel.png', testSkel)
                 print 'Medial axis computed '+str(time.time()-currT)+'s'
                 currT=time.time()
                 path,skelGraph,crownT['DIA_STM'],skelSize=seg.findThickestPath(testSkel,testDia,xScale,yScale)


### PR DESCRIPTION
The Topp lab likes to save the skeleton images in addition to the other DIRT outputs. This pull request modifies `main.py` to create a `Crown/Skeleton` output subdirectory and saves the `testSkel` image to the output directory. Credit to Molly Wohl for the updates.

If this change is not desired, please feel free to close this PR without merging.

Thanks!